### PR TITLE
ci: use a well known path for resolving project paths in order to res…

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -329,3 +329,4 @@ ASALocalRun/
 # MFractors (Xamarin productivity tool) working folder 
 .mfractor/
 Kafka.Protocol/LastMajorVersionBinary/
+nuget-packages/

--- a/Kafka.Protocol.v3.ncrunchsolution
+++ b/Kafka.Protocol.v3.ncrunchsolution
@@ -1,6 +1,8 @@
 ﻿<SolutionConfiguration>
   <Settings>
     <AllowParallelTestExecution>True</AllowParallelTestExecution>
+    <EnableRDI>True</EnableRDI>
+    <RdiConfigured>True</RdiConfigured>
     <SolutionConfigured>True</SolutionConfigured>
   </Settings>
 </SolutionConfiguration>

--- a/Kafka.Protocol/Kafka.Protocol.csproj
+++ b/Kafka.Protocol/Kafka.Protocol.csproj
@@ -4,7 +4,7 @@
     <TargetFramework>netstandard2.1</TargetFramework>
     <Nullable>enable</Nullable>
     <WarningsAsErrors>CS8600;CS8601;CS8603;CS8614;CS8618;CS8625</WarningsAsErrors>
-    <PackageReleaseNotes>$([System.IO.File]::ReadAllText('release_notes.txt'))</PackageReleaseNotes>
+    <PackageReleaseNotes>$([System.IO.File]::ReadAllText('$(MSBuildProjectDirectory)/release_notes.txt'))</PackageReleaseNotes>
     <PublishRepositoryUrl>true</PublishRepositoryUrl>
     <IncludeSymbols>true</IncludeSymbols>
     <SymbolPackageFormat>snupkg</SymbolPackageFormat>


### PR DESCRIPTION
…olve release_notes.txt to avoid issues with later versions of msbuild